### PR TITLE
Fix code scanning alert no. 80: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -18,7 +18,7 @@ class ErrorWithParent extends Error {
 // vuln-code-snippet start unionSqlInjectionChallenge dbSchemaChallenge
 module.exports = function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
-    let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    let criteria: any = (typeof req.query.q === 'string') ? req.query.q : ''
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Fixes [https://github.com/jojo-company/juice-shop2/security/code-scanning/80](https://github.com/jojo-company/juice-shop2/security/code-scanning/80)

To fix the problem, we need to ensure that the `req.query.q` parameter is a string before using it. This can be done by adding a type check for `req.query.q` and handling cases where it is not a string. If the parameter is not a string, we should treat it as an invalid input and handle it accordingly.

1. Add a type check for `req.query.q` to ensure it is a string.
2. If `req.query.q` is not a string, set `criteria` to an empty string or handle it as an invalid input.
3. This change should be made in the `routes/search.ts` file, specifically around lines 21-22.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
